### PR TITLE
Enabled data masking to work it properly within edc environment.

### DIFF
--- a/extensions/common/data-masking/src/main/java/org/eclipse/edc/connector/datamasking/DataMaskingConfiguration.java
+++ b/extensions/common/data-masking/src/main/java/org/eclipse/edc/connector/datamasking/DataMaskingConfiguration.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.datamasking;
 
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.configuration.Config;
 
 /**

--- a/extensions/common/data-masking/src/main/java/org/eclipse/edc/connector/datamasking/DataMaskingExtension.java
+++ b/extensions/common/data-masking/src/main/java/org/eclipse/edc/connector/datamasking/DataMaskingExtension.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.edc.connector.datamasking;
 
-import org.eclipse.edc.connector.datamasking.DataMaskingServiceImpl;
-import org.eclipse.edc.connector.datamasking.DataMaskingTransformer;
 import org.eclipse.edc.connector.datamasking.rules.EmailMaskingStrategy;
 import org.eclipse.edc.connector.datamasking.rules.NameMaskingStrategy;
 import org.eclipse.edc.connector.datamasking.rules.PhoneNumberMaskingStrategy;
@@ -26,8 +24,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
-
-import java.util.List;
 
 /**
  * Extension that provides data masking capabilities for sensitive fields

--- a/extensions/common/data-masking/src/test/java/org/eclipse/edc/connector/datamasking/DataMaskingExtensionTest.java
+++ b/extensions/common/data-masking/src/test/java/org/eclipse/edc/connector/datamasking/DataMaskingExtensionTest.java
@@ -23,14 +23,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.lang.reflect.Field;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.lang.reflect.Field;
 
 class DataMaskingExtensionTest {
 

--- a/extensions/common/data-masking/src/test/java/org/eclipse/edc/connector/datamasking/DataMaskingIntegrationTest.java
+++ b/extensions/common/data-masking/src/test/java/org/eclipse/edc/connector/datamasking/DataMaskingIntegrationTest.java
@@ -17,13 +17,10 @@ package org.eclipse.edc.connector.datamasking;
 import org.eclipse.edc.connector.datamasking.rules.EmailMaskingStrategy;
 import org.eclipse.edc.connector.datamasking.rules.NameMaskingStrategy;
 import org.eclipse.edc.connector.datamasking.rules.PhoneNumberMaskingStrategy;
-import org.eclipse.edc.connector.datamasking.spi.DataMaskingService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/extensions/common/data-masking/src/test/java/org/eclipse/edc/connector/datamasking/DataMaskingServiceImplTest.java
+++ b/extensions/common/data-masking/src/test/java/org/eclipse/edc/connector/datamasking/DataMaskingServiceImplTest.java
@@ -17,12 +17,9 @@ package org.eclipse.edc.connector.datamasking;
 import org.eclipse.edc.connector.datamasking.rules.EmailMaskingStrategy;
 import org.eclipse.edc.connector.datamasking.rules.NameMaskingStrategy;
 import org.eclipse.edc.connector.datamasking.rules.PhoneNumberMaskingStrategy;
-import org.eclipse.edc.connector.datamasking.spi.MaskingStrategy;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/extensions/common/data-masking/src/test/java/org/eclipse/edc/connector/datamasking/DataMaskingTransformerTest.java
+++ b/extensions/common/data-masking/src/test/java/org/eclipse/edc/connector/datamasking/DataMaskingTransformerTest.java
@@ -69,7 +69,7 @@ class DataMaskingTransformerTest {
     }
 
     @Test
-    void shouldReturnNullOnIOException() throws IOException {
+    void shouldReturnNullOnIoException() throws IOException {
         var inputStream = mock(InputStream.class);
         when(inputStream.transferTo(any())).thenThrow(new IOException("Test IO Exception"));
 

--- a/launchers/dpf-selector/build.gradle.kts
+++ b/launchers/dpf-selector/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":extensions:common:data-masking"))
     implementation(project(":extensions:common:api:api-observability"))
     api(project(":core:data-plane-selector:data-plane-selector-core"))
     api(project(":extensions:data-plane-selector:data-plane-selector-api"))

--- a/launchers/dpf-selector/config.properties
+++ b/launchers/dpf-selector/config.properties
@@ -15,3 +15,6 @@ web.http.port=8181
 web.http.path=/api
 web.http.management.port=9900
 web.http.management.path=/api/v1/dataplane
+
+edc.data.masking.enabled=true
+edc.data.masking.fields=name,phone,email


### PR DESCRIPTION
data masking enabled. Did the following.  
1. added the data-masking extension as a dependency in the launchers/dpf-selector/build.gradle.kts file, 
2. updated the config.properties file to enable the data masking service and configured it to mask the name, phone, and email fields. 
3. fixed the checkstyle errors in DataMaskingConfiguration, DataMaskingExtention and test files. The issues were primarily related to unused imports, incorrect import order, and method naming conventions in the data-masking extension